### PR TITLE
fix: avoid using a global force_load widget

### DIFF
--- a/ipyvue/ForceLoad.py
+++ b/ipyvue/ForceLoad.py
@@ -7,6 +7,3 @@ class ForceLoad(DOMWidget):
     _model_name = Unicode("ForceLoadModel").tag(sync=True)
     _model_module = Unicode("jupyter-vue").tag(sync=True)
     _model_module_version = Unicode(semver).tag(sync=True)
-
-
-force_load_instance = ForceLoad()

--- a/ipyvue/VueTemplateWidget.py
+++ b/ipyvue/VueTemplateWidget.py
@@ -1,11 +1,12 @@
 import os
-from traitlets import Any, Unicode, List, Dict, Union, Instance
+from traitlets import Any, Unicode, List, Dict, Union, Instance, default
 from ipywidgets import DOMWidget
 from ipywidgets.widgets.widget import widget_serialization
 
 from .Template import Template, get_template
 from ._version import semver
-from .ForceLoad import force_load_instance
+from .ForceLoad import ForceLoad
+from .util import singleton
 import inspect
 from importlib import import_module
 
@@ -94,11 +95,14 @@ class VueTemplate(DOMWidget, Events):
         "to_json": _class_to_json,
     }
 
-    # Force the loading of jupyter-vue before dependent extensions when in a static
-    # context (embed, voila)
-    _jupyter_vue = Any(force_load_instance, read_only=True).tag(
+    # see VueWidget
+    _jupyter_vue = Instance(ForceLoad, read_only=True).tag(
         sync=True, **widget_serialization
     )
+
+    @default("_jupyter_vue")
+    def _default_jupyter_vue(self):
+        return singleton(ForceLoad)
 
     _model_name = Unicode("VueTemplateModel").tag(sync=True)
 

--- a/ipyvue/util.py
+++ b/ipyvue/util.py
@@ -1,0 +1,24 @@
+from ipywidgets import Widget
+import threading
+
+
+lock = threading.Lock()
+
+
+def singleton(WidgetClass, **kwargs):
+    # find a 'shared' instance (singleton) to avoid creating
+    # too many widgets. In contexts where self.widgets is not
+    # a global dict, this allows different users/context to
+    # have a singleton without sharing the widget
+    with lock:
+        if hasattr(Widget, "widgets"):
+            # pre 8.0
+            all_widgets = Widget.widgets
+        if hasattr(Widget, "widgets"):
+            all_widgets = Widget._widgets
+        else:
+
+        for widget in all_widgets.values():
+            if isinstance(widget, WidgetClass):
+                return widget
+        return WidgetClass(**kwargs)

--- a/js/src/VueModel.js
+++ b/js/src/VueModel.js
@@ -34,4 +34,5 @@ VueModel.serializers = {
     ...DOMWidgetModel.serializers,
     children: { deserialize: unpack_models },
     v_slots: { deserialize: unpack_models },
+    _jupyter_vue: { deserialize: unpack_models },
 };

--- a/js/src/VueTemplateModel.js
+++ b/js/src/VueTemplateModel.js
@@ -29,4 +29,5 @@ VueTemplateModel.serializers = {
     template: { deserialize: unpack_models },
     components: { deserialize: unpack_models },
     _component_instances: { deserialize: unpack_models },
+    _jupyter_vue: { deserialize: unpack_models },
 };


### PR DESCRIPTION
Instead, we create a singleton on the fly when needed.

This also allows in multi-user environments to have 1 singleton per user.