### PR TITLE
fix: .fire_event silently passes on exceptions

### DIFF
--- a/ipyvue/VueWidget.py
+++ b/ipyvue/VueWidget.py
@@ -96,8 +96,12 @@ class Events(object):
         if len(difference) != 0:
             self._events = list(self._event_handlers_map.keys())
 
-    def fire_event(self, event, data):
-        self._event_handlers_map[event](self, event, data)
+    def fire_event(self, event, data=None):
+        """Manually trigger an event handler on the Python side."""
+        dispatcher = self._event_handlers_map[event]
+        # we don't call via the dispatcher, since that eats exceptions
+        for callback in dispatcher.callbacks:
+            callback(self, event, data or {})
 
     def _handle_event(self, _, content, buffers):
         event = content.get("event", "")


### PR DESCRIPTION
See https://github.com/jupyter-widgets/ipywidgets/blob/a79655d74809cc6d666f01a5953589e2730512f6/python/ipywidgets/ipywidgets/widgets/widget.py#L176
This might be useful when an event gets triggered from the frontend and there is no Python callstack, but this is a public API and probably used for testing, where you do want the exceptions to bubble up I think.

Note that the original `fire_event` is renamed to `_fire_event` and still used in `_handle_event`