### PR TITLE
feat: expose jupyterVue as a global variable in jupyter lab

### DIFF
--- a/js/src/labplugin.js
+++ b/js/src/labplugin.js
@@ -5,6 +5,7 @@ module.exports = {
     id: 'jupyter-vue',
     requires: [base.IJupyterWidgetRegistry],
     activate(app, widgets) {
+        window.jupyterVue = jupyterVue;
         widgets.registerWidget({
             name: 'jupyter-vue',
             version: jupyterVue.version,


### PR DESCRIPTION
This allows vue templates to get a reference to Vue (via window.jupyterVue.Vue).

We can use this to define "Vue" when we load external modules using requirejs which may depend on Vue.

E.g.:
```
    if(window.jupyterVue) {
        define("vue", [], () => window.jupyterVue.Vue);
    }
    requirejs(....)
```