### PR TITLE
feat: allow a vue template to have a data function

### DIFF
--- a/js/src/VueTemplateRenderer.js
+++ b/js/src/VueTemplateRenderer.js
@@ -75,7 +75,9 @@ function createComponentObject(model, parentView) {
     return {
         inject: ['viewCtx'],
         data() {
-            return { ...data, ...createDataMapping(model) };
+            // data that is only used in the template, and not synced with the backend/model
+            const dataTemplate = (vuefile.SCRIPT && vuefile.SCRIPT.data && vuefile.SCRIPT.data()) || {};
+            return { ...data, ...dataTemplate, ...createDataMapping(model) };
         },
         beforeCreate() {
             callVueFn('beforeCreate', this);


### PR DESCRIPTION
So we can do
```
<script>
module.exports = {
    data: () => ({
        items: [],
    }),
    created() {
        this.items = [];
    },
...
```

data needs to be a function because we can create multiple models out of a single template, but with different data.