### PR TITLE
Fix: event serialization fails for non-DOM-events

### DIFF
--- a/js/src/VueRenderer.js
+++ b/js/src/VueRenderer.js
@@ -75,10 +75,10 @@ function pickSerializable(object, depth=0, max_depth=2) {
 }
 
 export function eventToObject(event) {
-    if (event == null) {
-        return event;
+    if (event instanceof Event) {
+        return pickSerializable(event);
     }
-    return pickSerializable(event);
+    return event;
 }
 
 export function vueRender(createElement, model, parentView, slotScopes) {

--- a/tests/ui/test_events.py
+++ b/tests/ui/test_events.py
@@ -9,7 +9,7 @@ from IPython.display import display
 from unittest.mock import MagicMock
 
 
-def test_widget_button(solara_test, page_session: playwright.sync_api.Page):
+def test_event_basics(solara_test, page_session: playwright.sync_api.Page):
     inner = vue.Html(tag="div", children=["Click Me!"])
     outer = vue.Html(tag="dev", children=[inner])
     mock_outer = MagicMock()

--- a/tests/ui/test_events.py
+++ b/tests/ui/test_events.py
@@ -36,3 +36,26 @@ def test_event_basics(solara_test, page_session: playwright.sync_api.Page):
     inner_sel.click()
     page_session.locator("text=Clicked").wait_for()
     mock_outer.assert_called_once()
+
+
+def test_mouse_event(solara_test, page_session: playwright.sync_api.Page):
+    div = vue.Html(tag="div", children=["Click Me!"])
+    last_event_data = None
+
+    def on_click(widget, event, data):
+        nonlocal last_event_data
+        last_event_data = data
+        div.children = ["Clicked"]
+
+    div.on_event("click", on_click)
+    display(div)
+
+    # click in the div
+    box = page_session.locator("text=Click Me!").bounding_box()
+    assert box is not None
+    page_session.mouse.click(box["x"], box["y"])
+
+    page_session.locator("text=Clicked").wait_for()
+    assert last_event_data is not None
+    assert last_event_data["x"] == box["x"]
+    assert last_event_data["y"] == box["y"]


### PR DESCRIPTION
We did not test the serialization in #76 which introduced a bug (#78). This PR adds tests for both case and fixes #78. Although it does not test example in #78 we know this goes through the same codepath.

Ideally, we also test component event (https://vuejs.org/guide/components/events.html) but we do not support them in templates. Also, without ipyvuetify we do not have a widget that can emit a component event with a non-Event object as argument. We could decide to depend on ipvuetify for the test, or rely on the fact that the custom events in templates share a similar codepath.