### PR TITLE
fix: github url typo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -197,7 +197,7 @@ setup(
     },
     author="Mario Buikhuizen, Maarten Breddels",
     author_email="mbuikhuizen@gmail.com, maartenbreddels@gmail.com",
-    url="https://github.com/widgetto/ipyvue",
+    url="https://github.com/widgetti/ipyvue",
     keywords=[
         "ipython",
         "jupyter",


### PR DESCRIPTION
Hi there,

while checking versions on pypi, i just noticed that the url to the Homepage had a typo.

Thanks for nice library ;)