### PR TITLE
fix: broken project URL in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -197,7 +197,7 @@ setup(
     },
     author="Mario Buikhuizen, Maarten Breddels",
     author_email="mbuikhuizen@gmail.com, maartenbreddels@gmail.com",
-    url="https://github.com/widgetto/ipyvue",
+    url="https://github.com/widgetti/ipyvue",
     keywords=[
         "ipython",
         "jupyter",


### PR DESCRIPTION
I noticed on [ipyvue's project page on pypi.org](https://pypi.org/project/ipyvue/) that the "Homepage" link points to https://github.com/widgetto/ipyvue/ rather than https://github.com/widgetti/ipyvue/ and decided to fix it.