### PR TITLE
feat: allow v_model to be set after first render

### DIFF
--- a/js/src/VueRenderer.js
+++ b/js/src/VueRenderer.js
@@ -127,6 +127,9 @@ function addListeners(model, vueModel) {
         .forEach(key => model.on(`change:${key}`, listener));
 
     model.on('change:v_model', () => {
+        if (vueModel.v_model === "!!disabled!!") {
+            vueModel.$forceUpdate();
+        }
         if (model.get('v_model') !== vueModel.v_model) {
             vueModel.v_model = model.get('v_model'); // eslint-disable-line no-param-reassign
         }


### PR DESCRIPTION
Previously v_model didn't respond to changes if it wasn't set before first render.