### PR TITLE
fix: empty template on one line or no template tag causes error

### DIFF
--- a/js/src/VueTemplateRenderer.js
+++ b/js/src/VueTemplateRenderer.js
@@ -102,7 +102,9 @@ function createComponentObject(model, parentView) {
             ...createFullVueComponents(fullVueComponents),
         },
         computed: { ...vuefile.SCRIPT && vuefile.SCRIPT.computed, ...aliasRefProps(model) },
-        template: vuefile.TEMPLATE || template,
+        template: vuefile.TEMPLATE === undefined && vuefile.SCRIPT === undefined && vuefile.STYLE === undefined
+            ? template
+            : vuefile.TEMPLATE,
         beforeMount() {
             callVueFn('beforeMount', this);
         },


### PR DESCRIPTION
Having an empty template on one line or no tempate tag at all would incorrectly fallback to the deprecated template format where template tags were ommited.

See: https://github.com/spacetelescope/jdaviz/pull/2668
and https://github.com/widgetti/solara/pull/625