### PR TITLE
fix: a data value of `0` turns into `{}`

### DIFF
--- a/ipyvue/VueWidget.py
+++ b/ipyvue/VueWidget.py
@@ -123,7 +123,7 @@ class Events(object):
         dispatcher = self._event_handlers_map[event]
         # we don't call via the dispatcher, since that eats exceptions
         for callback in dispatcher.callbacks:
-            callback(self, event, data or {})
+            callback(self, event, data)
 
     def _handle_event(self, _, content, buffers):
         event = content.get("event", "")


### PR DESCRIPTION
Don't use truthyness here, but since None would also be a valid value, remove it entirely.