### PR TITLE
fix: detach on_msg handler on widget/template close

### DIFF
--- a/ipyvue/VueTemplateWidget.py
+++ b/ipyvue/VueTemplateWidget.py
@@ -59,6 +59,9 @@ class Events(object):
             else:
                 getattr(self, "vue_" + event)(data)
 
+    def _clear_event_handler(self):
+        self.on_msg(self._handle_event, remove=True)
+
 
 def _value_to_json(x, obj):
     if inspect.isclass(x):
@@ -163,6 +166,10 @@ class VueTemplate(DOMWidget, Events):
 
         for traitlet in sync_ref_traitlets:
             create_ref_and_observe(traitlet)
+
+    def close(self):
+        self._clear_event_handler()
+        super().close()
 
 
 __all__ = ["VueTemplate"]

--- a/ipyvue/VueWidget.py
+++ b/ipyvue/VueWidget.py
@@ -130,6 +130,9 @@ class Events(object):
         data = content.get("data", {})
         self._fire_event(event, data)
 
+    def _clear_event_handler(self):
+        self.on_msg(self._handle_event, remove=True)
+
 
 class VueWidget(DOMWidget, Events):
     # we can drop this when https://github.com/jupyter-widgets/ipywidgets/pull/3592
@@ -191,6 +194,10 @@ class VueWidget(DOMWidget, Events):
         """Make the widget invisible"""
 
         self.class_list.add("d-none")
+
+    def close(self):
+        self._clear_event_handler()
+        super().close()
 
 
 __all__ = ["VueWidget"]


### PR DESCRIPTION
This improves performance slightly, since we don't have to wait for garbage collection.