### PR TITLE
feat: add scoped CSS support for Vue 3

### DIFF
--- a/examples/ScopedCSS.ipynb
+++ b/examples/ScopedCSS.ipynb
@@ -1,0 +1,99 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Scoped CSS\n",
+    "\n",
+    "By default, CSS in ipyvue templates is **global** — it affects all elements on the page with matching selectors. Scoped CSS limits styles to the component that defines them.\n",
+    "\n",
+    "**How it works:** ipyvue uses Vue 3's `compileStyle` to add a unique `data-v-*` attribute to your component's elements and rewrites your CSS selectors to include it (e.g., `.my-class` → `.my-class[data-v-1]`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipyvue as vue\n",
+    "import ipywidgets as widgets\n",
+    "from traitlets import default"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Without scoped CSS (the problem)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class GlobalStyle(vue.VueTemplate):\n",
+    "    @default(\"template\")\n",
+    "    def _default_template(self):\n",
+    "        return \"\"\"\n",
+    "        <template>\n",
+    "            <span class=\"demo-text\">Widget A</span>\n",
+    "        </template>\n",
+    "        <style>\n",
+    "            .demo-text { color: red; }\n",
+    "        </style>\n",
+    "        \"\"\"\n",
+    "\n",
+    "widget_b = vue.Html(tag=\"span\", children=[\"Widget B (innocent bystander)\"], class_=\"demo-text\")\n",
+    "\n",
+    "widgets.VBox([GlobalStyle(), widget_b])  # Both turn red!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## With `<style scoped>`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ScopedStyle(vue.VueTemplate):\n",
+    "    @default(\"template\")\n",
+    "    def _default_template(self):\n",
+    "        return \"\"\"\n",
+    "        <template>\n",
+    "            <span class=\"demo-text-2\">Widget A (scoped)</span>\n",
+    "        </template>\n",
+    "        <style scoped>\n",
+    "            .demo-text-2 { color: green; }\n",
+    "        </style>\n",
+    "        \"\"\"\n",
+    "\n",
+    "widget_b = vue.Html(tag=\"span\", children=[\"Widget B (unaffected)\"], class_=\"demo-text-2\")\n",
+    "\n",
+    "widgets.VBox([ScopedStyle(), widget_b])  # Only Widget A is green"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
- Use Vue 3's native `compileStyle` from `vue/compiler-sfc` for scoped CSS transformation
- Pass scopeId to `compileTemplate` for automatic `data-v-*` attributes on elements
- Add UI test for scoped styles
- Add example notebook

## Implementation

Unlike the Vue 2 implementation which uses custom CSS rewriting, this uses Vue 3's built-in SFC compiler:

```javascript
const compiled = compileStyle({
    source: content,
    id: scopeId,
    scoped: true,
});
```

The scopeId is also passed to `compileTemplate` so the template compiler automatically adds the `data-v-*` attribute to elements.

## Related
- Vue 2 version: #103
- Base: vue3 branch (#82)