### PR TITLE
feat: support precompiled ES modules as template implementations

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -154,6 +154,8 @@ jobs:
           pip install "solara-server[starlette,dev] @ ${PKG_URL}/solara-server/solara_server-1.57.3-py3-none-any.whl"
           pip install "pytest-ipywidgets[all] @ ${PKG_URL}/pytest-ipywidgets/pytest_ipywidgets-1.57.3-py3-none-any.whl"
           pip install "jupyter_server<2"
+          # ipyvuetify's pin drags in a released ipyvue; put the branch wheel back
+          pip install --force-reinstall --no-deps ${wheel}
 
       - name: Install playwright browsers
         run: playwright install chromium

--- a/ipyvue/Template.py
+++ b/ipyvue/Template.py
@@ -76,6 +76,11 @@ class Template(Widget):
 
     template = Unicode(None, allow_none=True).tag(sync=True)
     source_url = Unicode(None, allow_none=True).tag(sync=True)
+    # When set, the component implementation comes from a precompiled ES
+    # module (see ipyvue.esm.define_module) instead of compiling `template`
+    # in the browser. `esm_export` selects the export (default: "default").
+    esm_module = Unicode(None, allow_none=True).tag(sync=True)
+    esm_export = Unicode(None, allow_none=True).tag(sync=True)
 
 
 __all__ = ["Template", "watch"]

--- a/ipyvue/__init__.py
+++ b/ipyvue/__init__.py
@@ -1,6 +1,7 @@
 from ._version import __version__
 from .Html import Html
 from .Template import Template, watch
+from .esm import Module, define_module
 from .VueWidget import VueWidget
 from .VueTemplateWidget import VueTemplate
 from .VueComponentRegistry import (

--- a/ipyvue/esm.py
+++ b/ipyvue/esm.py
@@ -27,6 +27,9 @@ class Module(Widget):
 
     name = Unicode().tag(sync=True)
     code = Unicode().tag(sync=True)
+    # when set, the module is imported from this url instead of shipping the
+    # code over the widget model (e.g. a bundle served from a static dir)
+    url = Unicode(None, allow_none=True).tag(sync=True)
     dependencies = ListTrait(Unicode(), default_value=[]).tag(sync=True)
 
 
@@ -41,10 +44,14 @@ def define_module(name: str, module: Union[str, Path]) -> Module:
         The ES module source, or a Path to it (e.g. a vite/rollup build with
         ``vue`` marked external).
     """
-    code = module.read_text(encoding="utf8") if isinstance(module, Path) else module
     dependencies = [n for n in _module_names if n != name]
     if name not in _module_names:
         _module_names.append(name)
+    if isinstance(module, str) and (
+        module.startswith("http") or module.startswith("/")
+    ):
+        return Module(url=module, name=name, dependencies=dependencies)
+    code = module.read_text(encoding="utf8") if isinstance(module, Path) else module
     return Module(code=code, name=name, dependencies=dependencies)
 
 

--- a/ipyvue/esm.py
+++ b/ipyvue/esm.py
@@ -9,7 +9,7 @@ bypassing the in-browser SFC compiler entirely.
 """
 
 from pathlib import Path
-from typing import List, Union
+from typing import List, Optional, Union
 
 from ipywidgets import Widget
 from traitlets import List as ListTrait
@@ -33,7 +33,9 @@ class Module(Widget):
     dependencies = ListTrait(Unicode(), default_value=[]).tag(sync=True)
 
 
-def define_module(name: str, module: Union[str, Path]) -> Module:
+def define_module(
+    name: str, module: Union[str, Path, None] = None, *, code: Optional[str] = None
+) -> Module:
     """Register an ES module under a name.
 
     Parameters
@@ -41,18 +43,24 @@ def define_module(name: str, module: Union[str, Path]) -> Module:
     name:
         Import-map name the module will be available under.
     module:
-        The ES module source, or a Path to it (e.g. a vite/rollup build with
-        ``vue`` marked external).
+        A url the module is served from (str, e.g. a bundle in the app's
+        static dir), or a Path to the module source on disk (e.g. a
+        vite/rollup build with ``vue`` marked external).
+    code:
+        The module source as a string (alternative to ``module``).
     """
+    if (module is None) == (code is None):
+        raise TypeError("pass either module (url or Path) or code")
     dependencies = [n for n in _module_names if n != name]
     if name not in _module_names:
         _module_names.append(name)
-    if isinstance(module, str) and (
-        module.startswith("http") or module.startswith("/")
-    ):
-        return Module(url=module, name=name, dependencies=dependencies)
-    code = module.read_text(encoding="utf8") if isinstance(module, Path) else module
-    return Module(code=code, name=name, dependencies=dependencies)
+    if code is not None:
+        return Module(code=code, name=name, dependencies=dependencies)
+    if isinstance(module, Path):
+        return Module(
+            code=module.read_text(encoding="utf8"), name=name, dependencies=dependencies
+        )
+    return Module(url=module, name=name, dependencies=dependencies)
 
 
 def get_module_names() -> List[str]:

--- a/ipyvue/esm.py
+++ b/ipyvue/esm.py
@@ -1,0 +1,55 @@
+"""ES module (ESM) support: ship precompiled bundles instead of .vue source.
+
+Mirrors ipyreact's module mechanism: ``define_module(name, code_or_path)``
+creates a ``Module`` widget whose code is sent to the frontend once, imported
+via es-module-shims, and registered in the import map under ``name``. Vue
+components exported by such a module can then be used as the implementation
+of a VueTemplate (see ``Template.esm_module`` / ``Template.esm_export``),
+bypassing the in-browser SFC compiler entirely.
+"""
+
+from pathlib import Path
+from typing import List, Union
+
+from ipywidgets import Widget
+from traitlets import List as ListTrait
+from traitlets import Unicode
+
+from ._version import semver
+
+_module_names: List[str] = []
+
+
+class Module(Widget):
+    _model_name = Unicode("ModuleModel").tag(sync=True)
+    _model_module = Unicode("jupyter-vue").tag(sync=True)
+    _model_module_version = Unicode(semver).tag(sync=True)
+
+    name = Unicode().tag(sync=True)
+    code = Unicode().tag(sync=True)
+    dependencies = ListTrait(Unicode(), default_value=[]).tag(sync=True)
+
+
+def define_module(name: str, module: Union[str, Path]) -> Module:
+    """Register an ES module under a name.
+
+    Parameters
+    ----------
+    name:
+        Import-map name the module will be available under.
+    module:
+        The ES module source, or a Path to it (e.g. a vite/rollup build with
+        ``vue`` marked external).
+    """
+    code = module.read_text(encoding="utf8") if isinstance(module, Path) else module
+    dependencies = [n for n in _module_names if n != name]
+    if name not in _module_names:
+        _module_names.append(name)
+    return Module(code=code, name=name, dependencies=dependencies)
+
+
+def get_module_names() -> List[str]:
+    return list(_module_names)
+
+
+__all__ = ["Module", "define_module", "get_module_names"]

--- a/js/src/Module.js
+++ b/js/src/Module.js
@@ -2,6 +2,7 @@ import { WidgetModel } from '@jupyter-widgets/base';
 import {
     invalidateModule,
     loadModuleFromCode,
+    loadModuleFromUrl,
     provideModule,
     requestModule,
 } from './esmVueTemplate';
@@ -18,6 +19,7 @@ export class ModuleModel extends WidgetModel {
                 _model_name: 'ModuleModel',
                 name: '',
                 code: '',
+                url: null,
                 dependencies: [],
             },
         };
@@ -26,7 +28,7 @@ export class ModuleModel extends WidgetModel {
     initialize(attributes, options) {
         super.initialize(attributes, options);
         this.load();
-        this.on('change:code', () => {
+        this.on('change:code change:url', () => {
             invalidateModule(this.get('name'));
             this.load();
         });
@@ -37,7 +39,10 @@ export class ModuleModel extends WidgetModel {
         try {
             const dependencies = this.get('dependencies') || [];
             await Promise.all(dependencies.map(dep => requestModule(dep)));
-            const module = await loadModuleFromCode(this.get('code'), name);
+            const url = this.get('url');
+            const module = url
+                ? await loadModuleFromUrl(url, name)
+                : await loadModuleFromCode(this.get('code'), name);
             if (module.default && typeof module.default.install === 'function') {
                 installModulePlugin(module.default);
             }

--- a/js/src/Module.js
+++ b/js/src/Module.js
@@ -1,0 +1,50 @@
+import { WidgetModel } from '@jupyter-widgets/base';
+import {
+    invalidateModule,
+    loadModuleFromCode,
+    provideModule,
+    requestModule,
+} from './esmVueTemplate';
+
+/* Ships a precompiled ES module (see ipyvue.esm.define_module). The code is
+ * imported via es-module-shims and provided to the named-module registry,
+ * where getEsmAsyncComponent consumers await it. */
+export class ModuleModel extends WidgetModel {
+    defaults() {
+        return {
+            ...super.defaults(),
+            ...{
+                _model_name: 'ModuleModel',
+                name: '',
+                code: '',
+                dependencies: [],
+            },
+        };
+    }
+
+    initialize(attributes, options) {
+        super.initialize(attributes, options);
+        this.load();
+        this.on('change:code', () => {
+            invalidateModule(this.get('name'));
+            this.load();
+        });
+    }
+
+    async load() {
+        const name = this.get('name');
+        try {
+            const dependencies = this.get('dependencies') || [];
+            await Promise.all(dependencies.map(dep => requestModule(dep)));
+            const module = await loadModuleFromCode(this.get('code'), name);
+            provideModule(name, module);
+        } catch (e) {
+            console.error(`ipyvue: failed to load ES module "${name}"`, e);
+            provideModule(name, e);
+        }
+    }
+}
+
+ModuleModel.serializers = {
+    ...WidgetModel.serializers,
+};

--- a/js/src/Module.js
+++ b/js/src/Module.js
@@ -5,6 +5,7 @@ import {
     provideModule,
     requestModule,
 } from './esmVueTemplate';
+import { installModulePlugin } from './VueComponentModel';
 
 /* Ships a precompiled ES module (see ipyvue.esm.define_module). The code is
  * imported via es-module-shims and provided to the named-module registry,
@@ -37,6 +38,9 @@ export class ModuleModel extends WidgetModel {
             const dependencies = this.get('dependencies') || [];
             await Promise.all(dependencies.map(dep => requestModule(dep)));
             const module = await loadModuleFromCode(this.get('code'), name);
+            if (module.default && typeof module.default.install === 'function') {
+                installModulePlugin(module.default);
+            }
             provideModule(name, module);
         } catch (e) {
             console.error(`ipyvue: failed to load ES module "${name}"`, e);

--- a/js/src/Template.js
+++ b/js/src/Template.js
@@ -11,6 +11,8 @@ class TemplateModel extends WidgetModel {
             ...{
                 _model_name: 'TemplateModel',
                 source_url: null,
+                esm_module: null,
+                esm_export: null,
             },
         };
     }

--- a/js/src/VueComponentModel.js
+++ b/js/src/VueComponentModel.js
@@ -8,6 +8,7 @@ import { version } from './version';
 const apps = new Set();
 const appsWithBaseComponents = new WeakSet();
 const registeredComponentsByApp = new WeakMap();
+const modulePlugins = new Set();
 
 export function addApp(app, widget_manager) {
     apps.add(app);
@@ -16,8 +17,17 @@ export function addApp(app, widget_manager) {
         app.component('jupyter-widget', jupyterWidgetComponent());
         appsWithBaseComponents.add(app);
     }
+    modulePlugins.forEach(plugin => app.use(plugin));
 
     return syncComponentModels(app, widget_manager);
+}
+
+/* An ES module (see esm.py) whose default export is a vue plugin registers
+ * its own components: we app.use it on every app, current and future.
+ * app.use ignores repeated installs of the same plugin. */
+export function installModulePlugin(plugin) {
+    modulePlugins.add(plugin);
+    apps.forEach(app => app.use(plugin));
 }
 
 async function syncComponentModels(app, widget_manager) {

--- a/js/src/VueTemplateRenderer.js
+++ b/js/src/VueTemplateRenderer.js
@@ -6,7 +6,7 @@ import { createObjectForNestedModel, eventToObject, vueRender } from './VueRende
 import { VueModel } from './VueModel';
 import { VueTemplateModel } from './VueTemplateModel';
 import { TemplateModel } from './Template';
-import {getAsyncComponent} from "./esmVueTemplate";
+import {getAsyncComponent, getEsmAsyncComponent, getEsmComponent} from "./esmVueTemplate";
 
 export function vueTemplateRender(model, parentView) {
     return Vue.h(createComponentObject(model, parentView));
@@ -30,8 +30,22 @@ function createComponentObject(model, parentView) {
 
     const componentEntries = Object.entries(model.get('components') || {});
     const instanceComponents = componentEntries.filter(([, v]) => v instanceof WidgetModel);
-    const classComponents = componentEntries.filter(([, v]) => !(v instanceof WidgetModel) && !(typeof v === 'string'));
+    const classComponents = componentEntries.filter(([, v]) => !(v instanceof WidgetModel) && !(typeof v === 'string') && !(v && v.esm_module));
+    const esmComponents = componentEntries.filter(([, v]) => v && v.esm_module);
     const fullVueComponents = componentEntries.filter(([, v]) => typeof v === 'string');
+
+    const esmModule = templateModel.get('esm_module');
+    if (esmModule) {
+        return getEsmAsyncComponent(esmModule, templateModel.get('esm_export'), {
+            ...createModelMixin(model, templateModel, parentView),
+            components: {
+                ...createInstanceComponents(instanceComponents, parentView),
+                ...createClassComponents(classComponents, model, parentView),
+                ...createFullVueComponents(fullVueComponents),
+                ...createEsmComponents(esmComponents),
+            },
+        });
+    }
 
     return getAsyncComponent(
         template,
@@ -41,6 +55,7 @@ function createComponentObject(model, parentView) {
                 ...createInstanceComponents(instanceComponents, parentView),
                 ...createClassComponents(classComponents, model, parentView),
                 ...createFullVueComponents(fullVueComponents),
+                ...createEsmComponents(esmComponents),
             },
         },
         {
@@ -231,6 +246,13 @@ function createClassComponents(components, containerModel, parentView) {
                 return Vue.h('div', ['temp-content']);
             },
         }),
+    }), {});
+}
+
+function createEsmComponents(components) {
+    return components.reduce((accumulator, [componentName, spec]) => ({
+        ...accumulator,
+        [componentName]: getEsmComponent(spec.esm_module, spec.esm_export),
     }), {});
 }
 

--- a/js/src/esmVueTemplate.js
+++ b/js/src/esmVueTemplate.js
@@ -302,7 +302,14 @@ async function init() {
 init();
 
 async function loadShim() {
+    if (window.importShim) {
+        return;
+    }
     if (document.querySelectorAll("script[src*=es-module-shims][type=module]").length || document.getElementById("es-module-shims")) {
+        /* another library is loading it; wait for its copy */
+        while (!window.importShim) {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+        }
         return;
     }
     return loadScript("module", toModuleUrl(esModuleShims), "es-module-shims")

--- a/js/src/esmVueTemplate.js
+++ b/js/src/esmVueTemplate.js
@@ -201,6 +201,18 @@ export function invalidateModule(name) {
     delete _moduleResolvers[name];
 }
 
+export async function loadModuleFromUrl(url, name) {
+    await init();
+    addVueImportMap();
+    const module = await importShim(url);
+    try {
+        importShim.addImportMap({ imports: { [name]: url } });
+    } catch (e) {
+        console.warn(`ipyvue: could not (re)map import "${name}"`, e);
+    }
+    return module;
+}
+
 export async function loadModuleFromCode(code, name) {
     await init();
     /* another library (e.g. ipyreact) may have replaced the importShim

--- a/js/src/esmVueTemplate.js
+++ b/js/src/esmVueTemplate.js
@@ -172,6 +172,93 @@ export async function addModule(name, module) {
     })
 }
 
+/* Named-module registry (mirrors ipyreact): ModuleModel widgets provide
+ * modules by name; consumers await them, so load order does not matter. */
+const _providedModules = {};
+const _moduleResolvers = {};
+
+export function provideModule(name, module) {
+    if (_moduleResolvers[name]) {
+        _moduleResolvers[name].resolve(module);
+        delete _moduleResolvers[name];
+    } else {
+        _providedModules[name] = Promise.resolve(module);
+    }
+}
+
+export function requestModule(name) {
+    if (!_providedModules[name]) {
+        _providedModules[name] = new Promise((resolve, reject) => {
+            _moduleResolvers[name] = { resolve, reject };
+        });
+    }
+    return _providedModules[name];
+}
+
+export function invalidateModule(name) {
+    /* next requestModule waits for a fresh provideModule (hot reload) */
+    delete _providedModules[name];
+    delete _moduleResolvers[name];
+}
+
+export async function loadModuleFromCode(code, name) {
+    await init();
+    /* another library (e.g. ipyreact) may have replaced the importShim
+     * global since init; re-add the vue mapping so this import resolves
+     * against the shim that will actually run it (same refresh toModule
+     * does for compiled SFCs) */
+    addVueImportMap();
+    const url = toModuleUrl(withSourceURL(code, `ipyvue-module:///${name}.mjs`));
+    const module = await importShim(url);
+    /* Also expose under the name for inter-module imports. Import maps
+     * cannot remap an already-resolved specifier (hot reload in the same
+     * page); the named-module registry is the source of truth, so a failed
+     * remap only means inter-module imports keep the previous version. */
+    try {
+        importShim.addImportMap({ imports: { [name]: url } });
+    } catch (e) {
+        console.warn(`ipyvue: could not (re)map import "${name}" (stale inter-module imports until page reload)`, e);
+    }
+    return module;
+}
+
+async function resolveModuleExport(moduleName, exportName) {
+    const module = await requestModule(moduleName);
+    if (module instanceof Error) {
+        /* ModuleModel provides its load error so consumers fail visibly */
+        throw module;
+    }
+    const component = module[exportName || 'default'];
+    if (!component) {
+        throw new Error(`Module "${moduleName}" has no export "${exportName || 'default'}"`);
+    }
+    return component;
+}
+
+/* Component whose implementation comes from a precompiled ES module instead
+ * of an in-browser compiled SFC. Mirrors compileSfc's output shape: the
+ * component's own options ride as mixins[0] so the ipyvue model mixin
+ * (mixins[1], providing the Python traits as data and the event methods)
+ * takes precedence over the component's own data() placeholders. */
+export function getEsmAsyncComponent(moduleName, exportName, mixin) {
+    return Vue.defineAsyncComponent(async () => {
+        const component = await resolveModuleExport(moduleName, exportName);
+        const { render, setup, __scopeId, ...rest } = component;
+        return {
+            ...(render && { render }),
+            ...(setup && { setup }),
+            ...(__scopeId && { __scopeId }),
+            mixins: [rest, mixin],
+        };
+    });
+}
+
+/* An ES module export used directly as a component (a tag inside another
+ * template): no model mixin, the component keeps its own props/emits. */
+export function getEsmComponent(moduleName, exportName) {
+    return Vue.defineAsyncComponent(() => resolveModuleExport(moduleName, exportName));
+}
+
 let _init_promise = null;
 let _vue_module_url = null;
 function vueModuleUrl() {
@@ -222,10 +309,12 @@ function expose(module) {
     const id = "_ipyvue2_" + (Math.random()).toString(36);
     window[id] = module;
     const names = Object.keys(module).join(", ")
+    /* no delete of the global: the blob can be evaluated more than once
+     * (import-map updates, or a second es-module-shims instance loaded by
+     * another library), and each evaluation reads it */
     return toModuleUrl(`
         const { ${names} } = window["${id}"];
         export default window["${id}"].default;
-        delete window["${id}"];
         export { ${names} };`)
 }
 

--- a/js/src/esmVueTemplate.js
+++ b/js/src/esmVueTemplate.js
@@ -3,7 +3,10 @@ import { parse, compileScript, compileStyle, compileTemplate } from 'vue/compile
 import esModuleShims from './es-module-shims-txt.js'
 import {transform} from "sucrase";
 
-window.esmsInitOptions = { shimMode: true };
+/* es-module-shims reads this global once, and there is only one shim per page
+ * (see loadShim below), so merge instead of overwrite: ipyreact needs
+ * mapOverrides to re-point an import map entry on hot reload, and so do we. */
+window.esmsInitOptions = { ...window.esmsInitOptions, shimMode: true, mapOverrides: true };
 
 function patchCompiledTemplateCode(code) {
     /* Vuetify slot props can contain a Vue ref object in \`ref\`. Passing that through

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -4,6 +4,7 @@ export { VueTemplateModel } from './VueTemplateModel';
 export { VueView, createViewContext } from './VueView';
 export { HtmlModel } from './Html';
 export { TemplateModel } from './Template';
+export { ModuleModel } from './Module';
 export { ForceLoadModel } from './ForceLoad';
 export { vueRender, getScope } from './VueRenderer';
 export { VueComponentModel, addApp, removeApp } from './VueComponentModel';

--- a/js/src/nodeps.js
+++ b/js/src/nodeps.js
@@ -7,6 +7,7 @@ export { VueTemplateModel } from './VueTemplateModel';
 export { VueView, createViewContext } from './VueView';
 export { HtmlModel } from './Html';
 export { TemplateModel } from './Template';
+export { ModuleModel } from './Module';
 export { ForceLoadModel } from './ForceLoad';
 export { vueRender, getScope } from './VueRenderer';
 export { VueComponentModel, addApp, removeApp } from './VueComponentModel';

--- a/tests/ui/test_esm_module.py
+++ b/tests/ui/test_esm_module.py
@@ -20,7 +20,7 @@ def test_esm_module_component(
 
         ipyvue.define_module(
             "esm-test-module",
-            """
+            code="""
             import { h } from "vue";
 
             export const Label = {
@@ -60,7 +60,7 @@ def test_esm_module_component_as_tag(
 
         ipyvue.define_module(
             "esm-click-module",
-            """
+            code="""
             import { h } from "vue";
 
             export const ClickButton = {
@@ -123,7 +123,7 @@ def test_esm_module_plugin_registers_components(
         # plain vue plugin, applied to every app
         ipyvue.define_module(
             "esm-plugin-module",
-            """
+            code="""
             import { h } from "vue";
 
             const Hello = {

--- a/tests/ui/test_esm_module.py
+++ b/tests/ui/test_esm_module.py
@@ -107,3 +107,52 @@ def test_esm_module_component_as_tag(
     page_session.locator(".esm-counter >> text=1 clicks").wait_for()
     counter.click()
     page_session.locator(".esm-counter >> text=2 clicks").wait_for()
+
+
+@pytest.mark.parametrize("ipywidgets_runner", ["solara"], indirect=True)
+def test_esm_module_plugin_registers_components(
+    ipywidgets_runner,
+    page_session: playwright.sync_api.Page,
+):
+    def kernel_code():
+        import traitlets
+        import ipyvue
+        from IPython.display import display
+
+        # the module registers its own components: the default export is a
+        # plain vue plugin, applied to every app
+        ipyvue.define_module(
+            "esm-plugin-module",
+            """
+            import { h } from "vue";
+
+            const Hello = {
+                props: { name: { type: String, required: true } },
+                render() {
+                    const text = `hello ${this.name}`;
+                    return h("div", { class: "esm-plugin-hello" }, text);
+                },
+            };
+
+            export default {
+                install(app) {
+                    app.component("esm-hello", Hello);
+                },
+            };
+            """,
+        )
+
+        class Widget(ipyvue.VueTemplate):
+            template = traitlets.Unicode(
+                """
+                <template>
+                    <esm-hello :name="name"></esm-hello>
+                </template>
+                """
+            ).tag(sync=True)
+            name = traitlets.Unicode("from python").tag(sync=True)
+
+        display(Widget())
+
+    ipywidgets_runner(kernel_code)
+    page_session.locator(".esm-plugin-hello >> text=hello from python").wait_for()

--- a/tests/ui/test_esm_module.py
+++ b/tests/ui/test_esm_module.py
@@ -1,0 +1,109 @@
+import pytest
+import sys
+
+if sys.version_info < (3, 7):
+    pytest.skip("requires python3.7 or higher", allow_module_level=True)
+
+import playwright.sync_api
+
+
+@pytest.mark.parametrize("ipywidgets_runner", ["solara"], indirect=True)
+def test_esm_module_component(
+    ipywidgets_runner,
+    page_session: playwright.sync_api.Page,
+):
+    def kernel_code():
+        import traitlets
+        import ipyvue
+        from ipywidgets import widget_serialization
+        from IPython.display import display
+
+        ipyvue.define_module(
+            "esm-test-module",
+            """
+            import { h } from "vue";
+
+            export const Label = {
+                data: () => ({ msg: "placeholder" }),
+                render() {
+                    return h("div", { class: "esm-widget" }, this.msg);
+                },
+            };
+            """,
+        )
+
+        class Widget(ipyvue.VueTemplate):
+            template = traitlets.Any().tag(sync=True, **widget_serialization)
+            msg = traitlets.Unicode("from python").tag(sync=True)
+
+            @traitlets.default("template")
+            def _template(self):
+                return ipyvue.Template(esm_module="esm-test-module", esm_export="Label")
+
+        display(Widget())
+
+    ipywidgets_runner(kernel_code)
+    # the model mixin must override the module's own data() placeholder
+    page_session.locator(".esm-widget >> text=from python").wait_for()
+
+
+@pytest.mark.parametrize("ipywidgets_runner", ["solara"], indirect=True)
+def test_esm_module_component_as_tag(
+    ipywidgets_runner,
+    page_session: playwright.sync_api.Page,
+):
+    def kernel_code():
+        import traitlets
+        import ipyvue
+        from ipywidgets import widget_serialization
+        from IPython.display import display
+
+        ipyvue.define_module(
+            "esm-click-module",
+            """
+            import { h } from "vue";
+
+            export const ClickButton = {
+                props: { count: { type: Number, required: true } },
+                emits: ["bump"],
+                render() {
+                    return h(
+                        "button",
+                        { class: "esm-counter", onClick: () => this.$emit("bump", 1) },
+                        `${this.count} clicks`,
+                    );
+                },
+            };
+            """,
+        )
+
+        class Widget(ipyvue.VueTemplate):
+            template = traitlets.Unicode(
+                """
+                <template>
+                    <click-button :count="count" @bump="on_bump"></click-button>
+                </template>
+                """
+            ).tag(sync=True)
+            count = traitlets.Int(0).tag(sync=True)
+            components = traitlets.Dict(
+                {
+                    "click-button": {
+                        "esm_module": "esm-click-module",
+                        "esm_export": "ClickButton",
+                    }
+                }
+            ).tag(sync=True, **widget_serialization)
+
+            def vue_on_bump(self, amount):
+                self.count += amount
+
+        display(Widget())
+
+    ipywidgets_runner(kernel_code)
+    # props flow in (count), events flow out (@bump -> python -> count += 1)
+    counter = page_session.locator(".esm-counter")
+    counter.click()
+    page_session.locator(".esm-counter >> text=1 clicks").wait_for()
+    counter.click()
+    page_session.locator(".esm-counter >> text=2 clicks").wait_for()


### PR DESCRIPTION
## Summary

`define_module(name, code_or_path)` ships an ES module once per kernel — imported through the existing es-module-shims/import-map machinery in `esmVueTemplate.js` — and `Template(esm_module=..., esm_export=...)` uses one of its exports as the component instead of compiling the template in the browser.

This makes it possible to build `.vue` files ahead of time (e.g. vite with `vue` external), with npm dependencies compiled in: no template source over the wire, and `vue/compiler-sfc` is not needed at runtime for these components. Same mechanism ipyreact modules use.

The export's options ride as `mixins[0]` under the ipyvue model mixin — the same precedence `compileSfc` produces — so model traits override the script's `data()` defaults and injected event handlers override methods, and existing templates work AOT-compiled without changes.

## Changes

- `ipyvue/esm.py`: `Module` widget + `define_module` (new, 55 lines)
- `js/src/Module.js`: imports the code, provides it to a named-module registry; re-imports on `change:code` (hot reload)
- `js/src/esmVueTemplate.js`: named-module registry + `getEsmAsyncComponent`
- `Template` gains `esm_module`/`esm_export` traits; `VueTemplateRenderer` branches to the ESM component when set
- A module whose default export is a plain vue plugin ({ install(app) }) registers its own components globally: ipyvue app.uses it on every vue app, current and future
- ES module exports can also be used as tags in any template via the `components` dict ({"esm_module": ..., "esm_export": ...}) — no mixin, the component keeps its own props/emits
- UI tests (`tests/ui/test_esm_module.py`): define_module → render → model-mixin precedence, and a props-in/events-out click-counter round trip for the tag form; both passing locally on the solara runner

Verified end to end with a vite-built bundle of real `.vue` templates (options API, `module.exports =` scripts) rendering with Python-injected data, events, and bundled npm dependencies. Solara-side kernel handling is a separate PR (widgetti/solara#1169).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
