### PR TITLE
fix: pass the previous value to template watchers

### DIFF
--- a/js/src/VueTemplateRenderer.js
+++ b/js/src/VueTemplateRenderer.js
@@ -268,9 +268,9 @@ function createWatches(model, parentView, templateWatchers) {
     .reduce((result, prop) => ({
         ...result,
         [prop]: {
-            handler(value) {
+            handler(value, oldValue) {
                 if (templateWatchers && templateWatchers[prop]) {
-                    templateWatchers[prop].bind(this)(value);
+                    templateWatchers[prop].bind(this)(value, oldValue);
                 }
                 /* Don't send changes received from backend back */
                 if (_.isEqual(value, model.get(prop))) {

--- a/tests/ui/test_watchers.py
+++ b/tests/ui/test_watchers.py
@@ -92,3 +92,36 @@ def test_watcher_vue(solara_test, page_session: Page):
     widget = page_session.locator("text=Click Me 0")
     widget.click()
     widget = page_session.locator("text=Clicked 1")
+
+
+class WatcherOldValueTemplate(vue.VueTemplate):
+    number = Int(0).tag(sync=True)
+    text = Unicode("old: ").tag(sync=True)
+
+    @default("template")
+    def _default_vue_template(self):
+        return """
+        <template>
+            <div @click="number += 1">{{text + number}}</div>
+        </template>
+        <script>
+        export default {
+            watch: {
+                number: function(value, oldValue) {
+                    this.text = "old: " + oldValue + " new: ";
+                }
+            }
+        }
+        </script>
+        """
+
+
+# Watchers follow the vue API: they also receive the previous value
+def test_watcher_old_value(solara_test, page_session: Page):
+    widget = WatcherOldValueTemplate()
+
+    display(widget)
+
+    element = page_session.locator("text=old: 0")
+    element.click()
+    page_session.locator("text=old: 0 new: 1").wait_for()


### PR DESCRIPTION
Watchers on model-backed properties are wrapped by `createWatches` (to sync changes back to the model), and the wrapper only forwarded the new value — vue's watcher API provides `(value, oldValue)`, so template watchers on synced properties never received the previous value.

Two-line fix in the wrapper; UI test included (fails without the fix, times out waiting for the oldValue-derived text).

The vue3 branch is not affected: there the script's own watchers are merged by vue itself (mixins), which passes both arguments natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
