### PR TITLE
fix: support object, string and array form template watchers

### DIFF
--- a/js/src/VueTemplateRenderer.js
+++ b/js/src/VueTemplateRenderer.js
@@ -262,6 +262,18 @@ function addModelListeners(model, vueModel) {
     });
 }
 
+/* vue allows function, {handler, ...}, method-name string and array watchers */
+function callTemplateWatcher(vm, watcher, value, oldValue) {
+    [].concat(watcher).forEach((entry) => {
+        const handler = typeof entry === 'object' ? entry.handler : entry;
+        (typeof handler === 'string' ? vm[handler] : handler).call(vm, value, oldValue);
+    });
+}
+
+function watchesImmediately(watcher) {
+    return [].concat(watcher || []).some(entry => entry && entry.immediate);
+}
+
 function createWatches(model, parentView, templateWatchers) {
     const modelWatchers = model.keys().filter(prop => !prop.startsWith('_')
     && !['events', 'template', 'components', 'layout', 'css', 'scoped', 'scoped_css_support', 'data', 'methods'].includes(prop))
@@ -270,7 +282,7 @@ function createWatches(model, parentView, templateWatchers) {
         [prop]: {
             handler(value, oldValue) {
                 if (templateWatchers && templateWatchers[prop]) {
-                    templateWatchers[prop].bind(this)(value, oldValue);
+                    callTemplateWatcher(this, templateWatchers[prop], value, oldValue);
                 }
                 /* Don't send changes received from backend back */
                 if (_.isEqual(value, model.get(prop))) {
@@ -281,6 +293,7 @@ function createWatches(model, parentView, templateWatchers) {
                 model.save_changes(model.callbacks(parentView));
             },
             deep: true,
+            immediate: watchesImmediately(templateWatchers && templateWatchers[prop]),
         },
     }), {})
     /* Overwritten keys from templateWatchers are handled in modelWatchers

--- a/tests/ui/test_watchers.py
+++ b/tests/ui/test_watchers.py
@@ -125,3 +125,40 @@ def test_watcher_old_value(solara_test, page_session: Page):
     element = page_session.locator("text=old: 0")
     element.click()
     page_session.locator("text=old: 0 new: 1").wait_for()
+
+
+class WatcherObjectFormTemplate(vue.VueTemplate):
+    number = Int(0).tag(sync=True)
+    text = Unicode("start").tag(sync=True)
+
+    @default("template")
+    def _default_vue_template(self):
+        return """
+        <template>
+            <div>{{text}}</div>
+        </template>
+        <script>
+        export default {
+            watch: {
+                number: {
+                    handler: function(value, oldValue) {
+                        this.text = "object saw " + oldValue + " -> " + value;
+                    },
+                    deep: true,
+                }
+            }
+        }
+        </script>
+        """
+
+
+# Object-form watchers ({handler, deep}) are valid vue and must not crash
+# when a synced trait changes from python
+def test_watcher_object_form(solara_test, page_session: Page):
+    widget = WatcherObjectFormTemplate()
+
+    display(widget)
+
+    page_session.locator("text=start").wait_for()
+    widget.number = 3
+    page_session.locator("text=object saw 0 -> 3").wait_for()


### PR DESCRIPTION
Template watchers on model-backed properties are wrapped by `createWatches` (to sync changes back to the model). The wrapper assumed the function form and crashed with `.bind is not a function` on vue's other legal watcher forms — `{handler, deep, immediate}`, a method-name string, or an array of those — whenever the synced trait changed from Python. In practice this meant only shorthand function watchers could be used on synced properties.

Fix: normalize to a handler list and honor `immediate`. Function-form watchers take the same path as before (a list of one); `immediate` fires the handler once at setup with `(value, undefined)`, and the model-sync short-circuit keeps that free of echo writes. No compatibility impact: the other forms previously never ran and crashed on the first python-side change, so nothing can depend on the old behavior.

UI test included: an object-form watcher reacting to a python-side trait change (times out without the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
